### PR TITLE
Rename command to scbw.play

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Testing and reporting in other settings is very welcome!
 
 Launch headful play of [PurpleWave](https://sscaitournament.com/index.php?action=botDetails&bot=PurpleWave) and [CherryPi](https://sscaitournament.com/index.php?action=botDetails&bot=CherryPi) on default map.
 
-    $ scbw --bots "krasi0" "CherryPi" --show_all
+    $ scbw.play --bots "krasi0" "CherryPi" --show_all
 
 Create game on the server (VNC viewer on port 5900) and wait for bots to join the game.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -2,7 +2,7 @@
 
 ## Help
 
-    $ scbw -h
+    $ scbw.play -h
 
 Contains a lot of options, quite well documented.
 
@@ -10,7 +10,7 @@ Contains a lot of options, quite well documented.
 
 Launch headful play of [PurpleWave](https://sscaitournament.com/index.php?action=botDetails&bot=PurpleWave) and [CherryPi](https://sscaitournament.com/index.php?action=botDetails&bot=CherryPi) on default map.
 
-    $ scbw --bots "PurpleWave" "CherryPi" --show_all
+    $ scbw.play --bots "PurpleWave" "CherryPi" --show_all
 
 ## Headless play
 
@@ -20,7 +20,7 @@ Simply add `--headless` option.
 
 Play against a bot
 
-    $ scbw --bots "PurpleWave" --human
+    $ scbw.play --bots "PurpleWave" --human
 
 ## Stop games that failed to finish
 


### PR DESCRIPTION
I don't know is this intended change or not, but in latest version command `scbw` changed name to `scbw.play`. Either this is intended change and you need just change documentation which this PR should address. Or this is some change by mistake, then please comment and I could close this PR. I think it is easier to made this PR then propose my help in changing documentation 😄 