### PR TITLE
Add ability specify host to which connect VNC viewers

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -12,6 +12,12 @@ Launch headful play of [PurpleWave](https://sscaitournament.com/index.php?action
 
     $ scbw.play --bots "PurpleWave" "CherryPi" --show_all
 
+**Note**: If you are running Docker Toolbox you may need run bots like that:
+
+    $ scbw.play --bots "PurpleWave" "CherryPi" --show_all --vnc_host 192.168.99.100
+
+where the 192.168.99.100 is address of your VM where docker machine is running.
+
 ## Headless play
 
 Simply add `--headless` option.

--- a/scbw/cli.py
+++ b/scbw/cli.py
@@ -7,7 +7,7 @@ import coloredlogs
 
 from .__init__ import VERSION
 from .defaults import *
-from .docker import BASE_VNC_PORT
+from .docker import BASE_VNC_PORT, VNC_HOST
 from .error import ScbwException
 from .game import run_game, GameType
 from .player import PlayerRace, bot_regex
@@ -86,6 +86,9 @@ parser.add_argument('--vnc_base_port', type=int, default=BASE_VNC_PORT,
                     help="VNC lowest port number (for server).\n"
                          "Each consecutive n-th client (player)\n"
                          "has higher port number - vnc_base_port+n ")
+parser.add_argument('--vnc_host', type=str, default=VNC_HOST,
+                    help="Address of the host on which VNC connections would be accessible\n"
+                         "default:\n{VNC_HOST}")
 
 # Settings
 parser.add_argument('--show_all', action="store_true",

--- a/scbw/docker.py
+++ b/scbw/docker.py
@@ -157,6 +157,7 @@ def check_docker_requirements(image: str):
 
 
 BASE_VNC_PORT = 5900
+VNC_HOST = "localhost"
 APP_DIR = "/app"
 LOG_DIR = f"{APP_DIR}/logs"
 SC_DIR = f"{APP_DIR}/sc"
@@ -207,6 +208,7 @@ def launch_image(
         bwapi_data_bwta2_dir: str,
 
         vnc_base_port: int,
+        vnc_host: int,
 
         # docker
         docker_image: str,
@@ -343,8 +345,9 @@ def launch_game(players: List[Player], launch_params: Dict[str, Any],
 
         for i, player in enumerate(players if show_all else players[:1]):
             port = launch_params['vnc_base_port'] + i
-            logger.info(f"Launching vnc viewer for {player} on port {port}")
-            launch_vnc_viewer(port)
+            host = launch_params['vnc_host']
+            logger.info(f"Launching vnc viewer for {player} on address {host}:{port}")
+            launch_vnc_viewer(host, port)
 
         logger.info("\n"
                     "In headful mode, you must specify and start the game manually.\n"

--- a/scbw/game.py
+++ b/scbw/game.py
@@ -46,6 +46,7 @@ class GameArgs(Namespace):
     bwapi_data_bwta_dir: str
     bwapi_data_bwta2_dir: str
     vnc_base_port: int
+    vnc_host: str
     show_all: bool
     read_overwrite: bool
     docker_image: str
@@ -97,6 +98,7 @@ def run_game(args: GameArgs, wait_callback: Optional[Callable] = None) -> Option
 
         # vnc
         vnc_base_port=args.vnc_base_port,
+        vnc_host=args.vnc_host,
 
         # docker
         docker_image=args.docker_image,

--- a/scbw/vnc.py
+++ b/scbw/vnc.py
@@ -13,6 +13,6 @@ def check_vnc_exists():
         raise Exception(f"vnc-viewer not found!")
 
 
-def launch_vnc_viewer(port: int):
+def launch_vnc_viewer(host: str, port: int):
     # launch in bg
-    os.spawnl(os.P_NOWAIT, shutil.which("vnc-viewer"), "vnc-viewer", f"localhost:{port}")
+    os.spawnl(os.P_NOWAIT, shutil.which("vnc-viewer"), "vnc-viewer", f"{host}:{port}")


### PR DESCRIPTION
Added command line parameter `--vnc_host`. By default `localhost`.
This is required if you run on the Docker Toolbox which run all docker containers inside VM
By giving ability to specify that as parameter, there no need to run VNC manually each time