### PR TITLE
Add automatic detection of docker-machine

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,8 @@ Launch headful play of [PurpleWave](https://sscaitournament.com/index.php?action
 
     $ scbw.play --bots "PurpleWave" "CherryPi" --show_all
 
-**Note**: If you are running Docker Toolbox you may need run bots like that:
+**Note**: If you are running Docker Toolbox, and automatical IP address discovery
+for Docker machine does not work, you may need run bots like that:
 
     $ scbw.play --bots "PurpleWave" "CherryPi" --show_all --vnc_host 192.168.99.100
 

--- a/scbw/cli.py
+++ b/scbw/cli.py
@@ -86,9 +86,9 @@ parser.add_argument('--vnc_base_port', type=int, default=BASE_VNC_PORT,
                     help="VNC lowest port number (for server).\n"
                          "Each consecutive n-th client (player)\n"
                          "has higher port number - vnc_base_port+n ")
-parser.add_argument('--vnc_host', type=str, default=VNC_HOST,
+parser.add_argument('--vnc_host', type=str, default='',
                     help="Address of the host on which VNC connections would be accessible\n"
-                         "default:\n{VNC_HOST}")
+                         "default:\n{VNC_HOST} or IP address of the docker-machine")
 
 # Settings
 parser.add_argument('--show_all', action="store_true",

--- a/scbw/docker.py
+++ b/scbw/docker.py
@@ -133,6 +133,28 @@ def remove_game_image(image_name):
     if has_image:
         call(f"docker rmi --force {image_name}", shell=True)
 
+"""
+ Checks that docker-machine is available on the computer
+"""
+def check_dockermachine():
+    logger.debug("checking docker-machine presence")
+    try:
+        out = subprocess.check_output(['docker-machine', 'version'])
+        out = out.decode("utf-8")
+        out = out.replace('docker-machine.exe', '').replace('docker-machine', '')
+        out = out.strip()
+        logger.debug(f"Using docker machine version {out}")
+        return True
+    except Exception as e:
+        logger.debug(f"Docker machine not present")
+        return False
+
+"""
+ Gets IP address of the default docker machine
+"""
+def dockermachine_ip() -> str:
+    out = subprocess.check_output(['docker-machine', 'ip'])
+    return out.decode("utf-8").strip()
 
 def check_output(*args, **kwargs):
     try:
@@ -316,7 +338,6 @@ def container_exit_code(container: str) -> int:
                                    "--format='{{.State.ExitCode}}'"])
     return int(out.decode("utf-8").strip("\n\r\t '\""))
 
-
 def cleanup_containers(containers: List[str]):
     subprocess.call(['docker', 'rm'] + containers)
 
@@ -330,6 +351,14 @@ def launch_game(players: List[Player], launch_params: Dict[str, Any],
     #
     if len(players) == 0:
         raise GameException("At least one player must be specified")
+
+    if launch_params['vnc_host'] == "":
+        if check_dockermachine():
+            vnc_host = dockermachine_ip()
+            logger.debug(f"Detected docker machine host as {vnc_host}. This address would be used for VNC conenctions")
+            launch_params['vnc_host'] = vnc_host
+        else:
+            launch_params['vnc_host'] = "locahost"
 
     for i, player in enumerate(players):
         launch_image(player, nth_player=i, num_players=len(players), **launch_params)


### PR DESCRIPTION
If specified `--vnc_host` then that value would be used.
Otherwise code checks for `docker-machine` presence,
and if present use result of `docker-machine` ip
If `docker-machine` not found, then use `localhost` as default