### PR TITLE
Change way Java emedded in the Docker container

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 publish.sh
+*.tar.gz

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,6 @@
 You should put your version of JRE here.
+Latest version of JRE could be found on [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html)
 
-You can put it under `jre_8_32bit_noinstall.zip`
-
-The way I've done it is to just zip
-windows 32bit oracle java 8 folder and it works.
+Please download Windows x86 version and place it in this folder.
 
 I don't put the zip directly in the repo because of potential license problems.

--- a/docker/dockerfiles/java.dockerfile
+++ b/docker/dockerfiles/java.dockerfile
@@ -8,10 +8,10 @@ ENV JAVA_DIR="$APP_DIR/java"
 USER starcraft
 WORKDIR $APP_DIR
 
-COPY --chown=starcraft:users jre_8_32bit_noinstall.zip jre.zip
+COPY --chown=starcraft:users jre-8u161-windows-i586.tar.gz jre.tar.gz
 RUN set -x \
-    && unzip -q jre.zip \
-    && mv jre1.8.0_152/ $JAVA_DIR/ \
-    && rm jre.zip
+    && tar -xzf jre.tar.gz \
+    && mv jre1.8.0_161/ $JAVA_DIR/ \
+    && rm jre.tar.gz
 
 COPY scripts/win_java32 /usr/bin/win_java32


### PR DESCRIPTION
When I trying to troubleshoot images, I have to build them. In the instructions there note that you should place `jre_8_32bit_noinstall.zip` in the `docker` folder. I initially go to the Oracle website in order to find latest Java executable, but did not find anything like that for Linux. There only jre-8u161-linux-i586.tar.gz for 32-bit version of JRE which I found. So I have to unpack TAR GZ archive and repackage it as ZIP in order to build. Which is not very obvious, and on Windows it will give not 100% same results as if image would be created in Linux (not interested for main usage, but possible solve some local issues).

From documentation standpoint would be probably better explicitly state that code from Oracle should be repackaged as ZIP archive, or replace code to use TAR GZ. and definitely provide information where to get archive required for packaging.

I no understand that I should take Windows version from Oracle website, but keep my initial thoughts, to indicate that I have initial confusion. For reference mostly.

This is potentially could interfere with #35 , specifically brownzach125@431f644dffbe7f9c7f1d5e2da0415f2d93f1be72, but it is better show
the code with explanation of idea behind change, then try to replicate
code with words. So if you think this is not worth the change, it could be scrapped. Or if it could be improved, that could serve as starting point.