### PR TITLE
The MAINTAINER directive deprecated

### DIFF
--- a/docker/dockerfiles/bwapi.dockerfile
+++ b/docker/dockerfiles/bwapi.dockerfile
@@ -1,5 +1,5 @@
 FROM starcraft:wine
-MAINTAINER Michal Sustr <michal.sustr@aic.fel.cvut.cz>
+LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 ENV SC_DIR="$APP_DIR/sc"
 ENV BWTA_DIR="$APP_DIR/bwta"

--- a/docker/dockerfiles/java.dockerfile
+++ b/docker/dockerfiles/java.dockerfile
@@ -1,5 +1,5 @@
 FROM starcraft:play
-MAINTAINER Michal Sustr <michal.sustr@aic.fel.cvut.cz>
+LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 
 ENV JAVA_DIR="$APP_DIR/java"

--- a/docker/dockerfiles/play.dockerfile
+++ b/docker/dockerfiles/play.dockerfile
@@ -1,5 +1,5 @@
 FROM starcraft:bwapi
-MAINTAINER Michal Sustr <michal.sustr@aic.fel.cvut.cz>
+LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 USER starcraft
 WORKDIR $APP_DIR

--- a/docker/dockerfiles/wine.dockerfile
+++ b/docker/dockerfiles/wine.dockerfile
@@ -1,6 +1,6 @@
 # Basic images to build up X server with wine.
 FROM ubuntu:xenial
-MAINTAINER Michal Sustr <michal.sustr@aic.fel.cvut.cz>
+LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 ENV APP_DIR /app
 ENV LOG_DIR $APP_DIR/logs

--- a/scbw/local_docker/game.dockerfile
+++ b/scbw/local_docker/game.dockerfile
@@ -1,5 +1,5 @@
 FROM starcraft:java
-MAINTAINER Michal Sustr <michal.sustr@aic.fel.cvut.cz>
+LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 #####################################################################
 USER starcraft


### PR DESCRIPTION
On the official site recommended using LABEL instead of that (See: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)