### PR TITLE
Make log files search sequence more strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ venv/
 # Logs
 *.log
 
+# Exclude log files placed for testing
+!tests/unittests/data/**/*.log
+
 # IPython
 .ipynb_checkpoints
 
@@ -43,3 +46,6 @@ logs/*
 release.sh
 py36to34.sh
 scripts/py36to34.py
+
+# VSCode
+.vscode/

--- a/scbw/logs.py
+++ b/scbw/logs.py
@@ -3,7 +3,7 @@ import glob
 
 
 def find_logs(log_dir: str, game_name: str) -> List[str]:
-    return glob.glob(f"{log_dir}/{game_name}*.log")
+    return glob.glob(f"{log_dir}/{game_name}_*.log")
 
 
 def find_replays(map_dir: str, game_name: str) -> List[str]:

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,3 +2,7 @@ These integration tests use `bats` for testing:
 https://github.com/sstephenson/bats
 
 It assumes `bats` command is in system path.
+
+To run unit tests, run following command from the root of the project
+
+    python -m unittest -v tests.unittests

--- a/tests/unittests/__init__.py
+++ b/tests/unittests/__init__.py
@@ -1,0 +1,9 @@
+import unittest
+from .files_test import TestFindFiles
+
+def suite():
+
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestFindFiles))
+
+    return suite

--- a/tests/unittests/data/logs_similar_names/GAME_test2_0_CherryPi_bot.log
+++ b/tests/unittests/data/logs_similar_names/GAME_test2_0_CherryPi_bot.log
@@ -1,0 +1,1 @@
+GAME_test2_0_CherryPi_bot

--- a/tests/unittests/data/logs_similar_names/GAME_test_0_Hao_Pan_bot.log
+++ b/tests/unittests/data/logs_similar_names/GAME_test_0_Hao_Pan_bot.log
@@ -1,0 +1,1 @@
+GAME_test_0_Hao_Pan_bot

--- a/tests/unittests/data/logs_similar_names/GAME_test_0_Hao_Pan_game.log
+++ b/tests/unittests/data/logs_similar_names/GAME_test_0_Hao_Pan_game.log
@@ -1,0 +1,1 @@
+GAME_test_0_Hao_Pan_game

--- a/tests/unittests/data/logs_similar_names/GAME_test_1_CherryPi_bot.log
+++ b/tests/unittests/data/logs_similar_names/GAME_test_1_CherryPi_bot.log
@@ -1,0 +1,1 @@
+GAME_test_1_CherryPi_bot

--- a/tests/unittests/data/logs_similar_names/GAME_test_1_CherryPi_game.log
+++ b/tests/unittests/data/logs_similar_names/GAME_test_1_CherryPi_game.log
@@ -1,0 +1,1 @@
+GAME_test_1_CherryPi_game

--- a/tests/unittests/files_test.py
+++ b/tests/unittests/files_test.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+from scbw.logs import find_logs
+
+class TestFindFiles(unittest.TestCase):
+    root_dir = os.path.dirname(__file__)
+
+    def test_logs(self):
+        test_files_dir = os.path.normpath(self.root_dir + "/data/logs_similar_names")
+        logs = find_logs(test_files_dir, "GAME_test")
+        self.assertEqual(4, len(logs), "Only 4 log files should be found")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Before it could capture log files with game names who has
same as current game name plus some symbols.

closes #51 
