### PR TITLE
allow reading port forwarding from bot.json

### DIFF
--- a/scbw/docker_utils.py
+++ b/scbw/docker_utils.py
@@ -301,6 +301,12 @@ def launch_image(
             env["JAVA_DEBUG_PORT"] = player.meta.javaDebugPort
         if player.meta.javaOpts is not None:
             env["JAVA_OPTS"] = player.meta.javaOpts
+        if player.meta.port is not None:
+            if isinstance(player.meta.port, int) or player.meta.port.isdigit():
+                ports.update({str(player.meta.port) + '/tcp': int(player.meta.port)})
+            else:
+                forward, local = [int(x) for x in player.meta.port.split(':')]
+                ports.update({str(local) + '/tcp': forward})
     else:
         command = ["/app/play_human.sh"]
 

--- a/scbw/player.py
+++ b/scbw/player.py
@@ -67,6 +67,7 @@ class BotJsonMeta:
     botProfileURL: Optional[str] = None  # link to website
     javaDebugPort: Optional[int] = None  # optionally allow attaching debugger
     javaOpts: Optional[str] = None # optional parameters to JVM
+    port : Optional[str] = None # optionally publish a custom port to the hos
 
 
 class BotPlayer(Player):
@@ -168,6 +169,7 @@ class BotPlayer(Player):
         meta.botProfileURL = json_spec['botProfileURL'] if 'botProfileURL' in json_spec else None
         meta.javaDebugPort = json_spec['javaDebugPort'] if 'javaDebugPort' in json_spec else None
         meta.javaOpts = json_spec['javaOpts'] if 'javaOpts' in json_spec else None
+        meta.port = json_spec['port'] if 'port' in json_spec else None
 
         return meta
 

--- a/scbw/player.py
+++ b/scbw/player.py
@@ -67,7 +67,7 @@ class BotJsonMeta:
     botProfileURL: Optional[str] = None  # link to website
     javaDebugPort: Optional[int] = None  # optionally allow attaching debugger
     javaOpts: Optional[str] = None # optional parameters to JVM
-    port : Optional[str] = None # optionally publish a custom port to the hos
+    port : Optional[str] = None # optionally publish a custom port to the host
 
 
 class BotPlayer(Player):


### PR DESCRIPTION
## Motivation
This allows bots to run outside Docker and communicate with BWAPI over TCP (like TorchCraft bots do